### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.14
+
+RUN apk add git mosquitto-dev build-base
+
+WORKDIR /app
+
+RUN git clone https://github.com/ahpohl/libabbaurora.git 
+RUN cd /app/libabbaurora && sed -i 's/ln\s-sr\(.*\)/ln -s \1/g' Makefile && PREFIX=/usr make install
+RUN git clone https://github.com/ahpohl/solarmeter.git && cp /app/libabbaurora/include/*.h /app/solarmeter/include && cd /app/solarmeter && make install
+
+ENTRYPOINT ["/usr/local/bin/solarmeter"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ The Solarmeter daemon is built upon the [libabbaurora](https://ahpohl.github.io/
 
 The software stack is light weight in terms of necessary resources and runs on any SBC such as an Odroid C2/C4 or Raspberry Pi 3/4.
 
+## Run in docker
+
+You can build and run the binary from docker. This is an easy solution if you want to run on a less setup (like synology)
+
+```
+docker -v $(pwd)/config.conf:/app/config.conf --device /dev/ttyUSB0 run jekkos/solarmeter:latest -c /app/config.conf
+```
+
 ## Changelog
 
 All notable changes and releases are documented in the [CHANGELOG](CHANGELOG.md).


### PR DESCRIPTION
This PR adds a Dockerfile that allows you to run the meter using Docker. I found it easier to use docker on a synology as it lacks a proper package manager.